### PR TITLE
Implement repository test and CI workflow

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.6.10'
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -35,6 +35,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Install danger
+        run: |
+          gem install bundler
+          bundle install
       - name: Run Test
         run: ./gradlew test --stacktrace
       - name: Copy Test Result

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -1,4 +1,4 @@
-name: Build debug application
+name: Run test
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  run_test:
     runs-on: ubuntu-latest
     env:
       JVM_OPTS: '-Xmx2048m -Xms512m'
@@ -47,4 +47,4 @@ jobs:
         if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: danger --danger_id=testAffectedModules
+        run: danger --danger_id=test

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -21,10 +21,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
-          architecture: 'x64'
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -1,0 +1,50 @@
+name: Build debug application
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      JVM_OPTS: '-Xmx2048m -Xms512m'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC" -Dorg.gradle.daemon=false'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Setup ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          architecture: 'x64'
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run Test
+        run: ./gradlew test --stacktrace
+      - name: Copy Test Result
+        if: always()
+        run: |
+          mkdir -p ./test-results
+          find . -type f -regex ".*/test-results/.*/.*.xml" | xargs -r cp --parents --target-directory=./test-results
+      - name: Run danger
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: danger --danger_id=testAffectedModules

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,30 @@
+github.dismiss_out_of_range_messages
+
+# ktlint
+checkstyle_format.base_path = Dir.pwd
+Dir.glob("./ktlint/**/ktlint*.xml").each { |report|
+  checkstyle_format.report report.to_s
+}
+
+# android lint
+Dir.glob("./lint/**/lint-*.xml").each { |report|
+  # Lint only added/modified files
+  android_lint.filtering = true
+
+  # Already have lint xml, set true
+  android_lint.skip_gradle_task = true
+
+  android_lint.report_file = report.to_s
+
+  # Show suggestion only above on this severity
+  # android_lint.severity = "Error"
+
+  # Fire ;-)
+  android_lint.lint(inline_mode: true)
+}
+
+Dir.glob("./test-results/**/*.xml").each { |report|
+  junit.parse(report)
+  junit.show_skipped_tests = true
+  junit.report
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem 'danger'
+gem 'danger-checkstyle_format'
+gem 'danger-android_lint'
+gem 'danger-junit'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
     // Local tests: jUnit, coroutines, Android runner
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 
     // Instrumented tests: jUnit rules and runners
 

--- a/app/src/test/java/dev/dokup/cisample/data/DefaultLegendRepositoryTest.kt
+++ b/app/src/test/java/dev/dokup/cisample/data/DefaultLegendRepositoryTest.kt
@@ -45,7 +45,7 @@ class DefaultLegendRepositoryTest {
         val features = mutableListOf<Future<TakadaLegendResponse>>()
         repository.fetchLegend.toCollection(features)
 
-        assertEquals(3, features.size)
+        assertEquals(2, features.size)
         assertEquals(true, features[0] is Future.Proceeding)
         assertEquals(true, features[1] is Future.Success)
 

--- a/app/src/test/java/dev/dokup/cisample/data/DefaultLegendRepositoryTest.kt
+++ b/app/src/test/java/dev/dokup/cisample/data/DefaultLegendRepositoryTest.kt
@@ -16,22 +16,16 @@
 
 package dev.dokup.cisample.data
 
-import androidx.test.core.app.ActivityScenario.launch
-import app.cash.turbine.test
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import dev.dokup.cisample.data.local.database.Legend
 import dev.dokup.cisample.data.local.database.LegendDao
 import dev.dokup.cisample.data.remote.api.TakadaLegendResponse
 import dev.dokup.cisample.data.remote.api.TakadaLegendsApi
 import dev.dokup.cisample.data.remote.api.misc.Future
-import dev.dokup.cisample.data.remote.api.misc.apiFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
 import retrofit2.Response
 
 /**
@@ -51,7 +45,7 @@ class DefaultLegendRepositoryTest {
         val features = mutableListOf<Future<TakadaLegendResponse>>()
         repository.fetchLegend.toCollection(features)
 
-        assertEquals(2, features.size)
+        assertEquals(3, features.size)
         assertEquals(true, features[0] is Future.Proceeding)
         assertEquals(true, features[1] is Future.Success)
 

--- a/app/src/test/java/dev/dokup/cisample/data/DefaultLegendRepositoryTest.kt
+++ b/app/src/test/java/dev/dokup/cisample/data/DefaultLegendRepositoryTest.kt
@@ -16,15 +16,23 @@
 
 package dev.dokup.cisample.data
 
+import androidx.test.core.app.ActivityScenario.launch
+import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import dev.dokup.cisample.data.local.database.Legend
 import dev.dokup.cisample.data.local.database.LegendDao
+import dev.dokup.cisample.data.remote.api.TakadaLegendResponse
+import dev.dokup.cisample.data.remote.api.TakadaLegendsApi
+import dev.dokup.cisample.data.remote.api.misc.Future
+import dev.dokup.cisample.data.remote.api.misc.apiFlow
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import retrofit2.Response
 
 /**
  * Unit tests for [DefaultLegendRepository].
@@ -33,12 +41,29 @@ import dev.dokup.cisample.data.local.database.LegendDao
 class DefaultLegendRepositoryTest {
 
     @Test
-    fun legends_newItemSaved_itemIsReturned() = runTest {
-        val repository = DefaultLegendRepository(FakeLegendDao())
+    fun legends_fetchLegend_successGetLegend() = runTest {
+        val api = FakeLegendApi()
+        val repository = DefaultLegendRepository(
+            takadaLegendsApi = api,
+            legendDao = FakeLegendDao()
+        )
 
-        repository.add("Repository")
+        val features = mutableListOf<Future<TakadaLegendResponse>>()
+        repository.fetchLegend.toCollection(features)
 
-        assertEquals(repository.legends.first().size, 1)
+        assertEquals(2, features.size)
+        assertEquals(true, features[0] is Future.Proceeding)
+        assertEquals(true, features[1] is Future.Success)
+
+        val succeededResult = features[1] as Future.Success
+        val expectedNo = 15
+        val expectedText = """
+                ある意地の悪い華族が高田健志を自宅に招き、「1時間私を楽しませてみせよ」と大きな砂時計を逆さにした。
+                もちろん平民の話を最後まで聞くつもりなど彼にはなく、頃合いを見て追い返してやるつもりであった。
+                そろそろ5分経ったと見た彼は「つまらん」と立ち上がった。砂はすっかり落ち切っていた。
+            """.trimIndent()
+        assertEquals(expectedNo, succeededResult.value.no)
+        assertEquals(expectedText, succeededResult.value.text)
     }
 
 }
@@ -53,5 +78,20 @@ private class FakeLegendDao : LegendDao {
 
     override suspend fun insertLegend(item: Legend) {
         data.add(0, item)
+    }
+}
+
+private class FakeLegendApi : TakadaLegendsApi {
+
+    private val response = TakadaLegendResponse(
+        no = 15,
+        text = """
+            ある意地の悪い華族が高田健志を自宅に招き、「1時間私を楽しませてみせよ」と大きな砂時計を逆さにした。
+            もちろん平民の話を最後まで聞くつもりなど彼にはなく、頃合いを見て追い返してやるつもりであった。
+            そろそろ5分経ったと見た彼は「つまらん」と立ち上がった。砂はすっかり落ち切っていた。
+        """.trimIndent()
+    )
+    override suspend fun getRandomLegend(): Response<TakadaLegendResponse> {
+        return Response.success(response)
     }
 }

--- a/app/src/test/java/dev/dokup/cisample/ui/legend/LegendViewModelTest.kt
+++ b/app/src/test/java/dev/dokup/cisample/ui/legend/LegendViewModelTest.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import dev.dokup.cisample.data.LegendRepository
+import dev.dokup.cisample.data.remote.api.TakadaLegendResponse
+import dev.dokup.cisample.data.remote.api.misc.Future
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -56,4 +58,7 @@ private class FakeLegendRepository : LegendRepository {
     override suspend fun add(name: String) {
         data.add(0, name)
     }
+
+    override val fetchLegend: Flow<Future<TakadaLegendResponse>>
+        get() = TODO("Not yet implemented")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ retrofit = "2.9.0"
 kotlinxSerialization = "1.5.0"
 kotlinxSerializationPlugin = "1.8.10"
 retrofitKotlinxSerializationConverter = "0.8.0"
+turbine = "0.12.1"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
@@ -54,6 +55,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit"}
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 retrofit-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter"}
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine"}
 
 
 [plugins]


### PR DESCRIPTION
# TL; DR

Repositoryのユニットテストを実行するCIとそこで実行されるテストを実装しました

# What's changed

- DefaultLegendRepositoryTestの現状に即した状態の再実装
- `./gradlew test --stacktrace` を実行するCIの作成
  - dangerを実行してリザルトをコメント
  - artifactにリザルト置きたいんだよな